### PR TITLE
更新Dockerfile，支持CPU/GPU（2021.1构建运行成功）

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,4 +1,7 @@
-FROM ubuntu
+### 构建命令：docker build -t chineseocr -f Dockerfile.gpu .
+### 运行命令：docker run --runtime=nvidia -d -p 8080:8080 chineseocr /root/anaconda3/bin/python app.py
+
+FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
 MAINTAINER https://github.com/chineseocr/chineseocr
 
 #换成ubuntu国内镜像源
@@ -32,8 +35,9 @@ RUN (echo 'channels:'; \
 RUN yes | /root/anaconda3/bin/conda update --all
 RUN yes | /root/anaconda3/bin/conda install python=3.6
 
-RUN /root/anaconda3/bin/pip install easydict opencv-python-headless Cython 'h5py<3.0.0' pandas requests bs4 matplotlib lxml web.py==0.40.dev0 -U pillow keras==2.1.5 tensorflow==1.8 -i https://pypi.tuna.tsinghua.edu.cn/simple/
-RUN yes | /root/anaconda3/bin/conda install pytorch-cpu torchvision-cpu -c pytorch
+
+RUN /root/anaconda3/bin/pip install easydict opencv-python-headless Cython 'h5py<3.0.0' pandas requests bs4 matplotlib lxml web.py==0.40.dev0 -U pillow keras==2.1.5 tensorflow-gpu==1.8 -i https://pypi.tuna.tsinghua.edu.cn/simple/
+RUN yes | /root/anaconda3/bin/conda install pytorch torchvision cudatoolkit=9.0 -c pytorch
 
 
 COPY . /chineseocr


### PR DESCRIPTION
原来的Dockerfile现在已经不能build了（似乎会卡在解决依赖关系上）
更新后的Dockerfile能成功build且能运行示例了
另外还添加了Dockerfile.gpu，支持gpu运行（需要nvidia-docker）