### PR TITLE
removed a pitfall where a built-in name was being shadowed

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,7 +172,7 @@ class OCR:
         
         
         
-                    if billModel=='' or billModel=='通用OCR' :
+                    if billModel in ('', '通用OCR'):
                         result = union_rbox(result,0.2)
                         res = [{'text':x['text'],
                                 'name':str(i),


### PR DESCRIPTION
**Problem**:
The code was incurring into the consider-using-in pitfall case, as described by Pylint documentation here https://github.com/vald-phoenix/pylint-errors/blob/master/plerr/errors/refactoring/R1714.md

**Solution**:
Applied adequate refactoring. Only a single line of code was changed